### PR TITLE
feat: Add R13 webhook_acknowledgment rule config

### DIFF
--- a/src/stubs/flowlint-config.ts
+++ b/src/stubs/flowlint-config.ts
@@ -42,10 +42,22 @@ export const defaultConfig = {
     config_literals: {
       enabled: true,
       denylist_regex: [
-        '(?i)\b(dev|development)\b',
-        '(?i)\b(stag|staging)\b',
-        '(?i)\b(prod|production)\b',
-        '(?i)\b(test|testing)\b',
+        '(?i)\\b(dev|development)\\b',
+        '(?i)\\b(stag|staging)\\b',
+        '(?i)\\b(prod|production)\\b',
+        '(?i)\\b(test|testing)\\b',
+      ],
+    },
+    webhook_acknowledgment: {
+      enabled: true,
+      heavy_node_types: [
+        'n8n-nodes-base.httpRequest',
+        'n8n-nodes-base.postgres',
+        'n8n-nodes-base.mysql',
+        'n8n-nodes-base.mongodb',
+        'n8n-nodes-base.openAi',
+        'n8n-nodes-base.anthropic',
+        'n8n-nodes-base.huggingFace',
       ],
     },
   },


### PR DESCRIPTION
Adds webhook_acknowledgment rule configuration to Chrome Extension stub config, aligning with flowlint-app PR #145.

## Changes

- Added  rule with default  list  
- Detects webhooks performing heavy processing before acknowledgment
- Configuration includes HTTP requests, database queries, and AI/LLM calls as heavy operations

## Heavy Node Types

- HTTP requests ()
- Database queries (, , )
- AI/LLM calls (, , )

## Related

- flowlint-app PR #145: R13 implementation
- flowlint-web PR #21: Documentation update