### PR TITLE
chore: release chrome extension v0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flowlint-chrome",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bumps version to 0.4.1 to match backend capabilities (R13 support).