### PR TITLE
docs(chrome): update coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FlowLint Chrome Extension
 
-![Coverage](https://img.shields.io/badge/coverage-33%25-red)
+![Coverage](https://img.shields.io/badge/coverage-94%25-brightgreen)
 
 A browser extension for the [n8n](https://n8n.io) workflow editor that provides real-time linting using the FlowLint engine.
 


### PR DESCRIPTION
Updates the static coverage badge in README.md to reflect the actual test coverage (~94%).