### PR TITLE
ci(chrome): automate coverage badge updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   CI:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -28,6 +30,17 @@ jobs:
 
       - name: Run tests with coverage
         run: npm run test:coverage
+
+      - name: Update Coverage Badge
+        if: github.ref == 'refs/heads/main'
+        run: |
+          node scripts/update-badge.js
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          # Commit only if changes exist
+          git diff --quiet && git diff --staged --quiet || git commit -m "docs: update coverage badge [skip ci]"
+          git push
 
       - name: Build
         run: npm run build

--- a/scripts/update-badge.js
+++ b/scripts/update-badge.js
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+
+// Config
+const COVERAGE_FILE = path.join(__dirname, '../coverage/coverage-summary.json');
+const README_FILE = path.join(__dirname, '../README.md');
+
+// Colors
+const COLOR_BRIGHTGREEN = 'brightgreen'; // 90-100%
+const COLOR_GREEN = 'green';             // 80-90%
+const COLOR_YELLOW = 'yellow';           // 60-80%
+const COLOR_RED = 'red';                 // < 60%
+
+function getColor(pct) {
+  if (pct >= 90) return COLOR_BRIGHTGREEN;
+  if (pct >= 80) return COLOR_GREEN;
+  if (pct >= 60) return COLOR_YELLOW;
+  return COLOR_RED;
+}
+
+try {
+  if (!fs.existsSync(COVERAGE_FILE)) {
+    console.error(`Coverage file not found at: ${COVERAGE_FILE}`);
+    process.exit(1);
+  }
+
+  const coverage = JSON.parse(fs.readFileSync(COVERAGE_FILE, 'utf8'));
+  const pct = coverage.total.lines.pct;
+  const color = getColor(pct);
+  
+  // Badge format: ![Coverage](https://img.shields.io/badge/coverage-94%25-brightgreen)
+  // We match broadly to capture any previous color or percentage
+  const badgeRegex = /!\[Coverage\]\(https:\/\/img\.shields\.io\/badge\/coverage-[0-9.]+%25-[a-zA-Z]+\)/;
+  const newBadge = `![Coverage](https://img.shields.io/badge/coverage-${pct}%25-${color})`;
+
+  if (!fs.existsSync(README_FILE)) {
+    console.error(`README file not found at: ${README_FILE}`);
+    process.exit(1);
+  }
+
+  let readme = fs.readFileSync(README_FILE, 'utf8');
+  
+  if (badgeRegex.test(readme)) {
+    readme = readme.replace(badgeRegex, newBadge);
+    fs.writeFileSync(README_FILE, readme);
+    console.log(`Updated README badge to ${pct}% (${color})`);
+  } else {
+    console.warn('Coverage badge not found in README. Add ![Coverage](...) placeholder first.');
+    // Optional: Append if missing? Better not to mess up structure.
+  }
+
+} catch (error) {
+  console.error('Failed to update coverage badge:', error);
+  process.exit(1);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     ],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html', 'clover', 'cobertura'],
+      reporter: ['text', 'json', 'html', 'clover', 'cobertura', 'json-summary'],
       include: ['src/**'],
       exclude: [
         'src/**/*.test.ts', 


### PR DESCRIPTION
Adds a CI step to automatically update the coverage badge in README.md on every push to main.